### PR TITLE
Feature/11/mostrar prestamos finalizados

### DIFF
--- a/src/main/java/com/iesam/digitallibrary/feature/Main.java
+++ b/src/main/java/com/iesam/digitallibrary/feature/Main.java
@@ -36,6 +36,7 @@ public class Main {
             System.out.println("---PRESTAMOS---");
             System.out.println("9. Añadir Prestamo");
             System.out.println("10. Borrar Prestamo");
+            System.out.println("11. Mostrar Prestamos Finalizados");
 
 
             System.out.println("Selecciona una opcion: ");
@@ -81,7 +82,10 @@ public class Main {
                 case 10:
                     LoanMain.deleteLoan();
                     break;
-                    LoanMain.addUser();
+
+                case 11:
+                    LoanMain.getFinishedLoan();
+                    break;
             }
 
         }

--- a/src/main/java/com/iesam/digitallibrary/feature/loan/data/LoanDataRepository.java
+++ b/src/main/java/com/iesam/digitallibrary/feature/loan/data/LoanDataRepository.java
@@ -22,4 +22,9 @@ public class LoanDataRepository implements LoanRepository {
         loanFileLocalDataSource.delete(id);
     }
 
+    @Override
+    public void getFinishedLoans() {
+        loanFileLocalDataSource.getFinishedLoan();
+    }
+
 }

--- a/src/main/java/com/iesam/digitallibrary/feature/loan/data/local/LoanFileLocalDataSource.java
+++ b/src/main/java/com/iesam/digitallibrary/feature/loan/data/local/LoanFileLocalDataSource.java
@@ -125,6 +125,7 @@ public class LoanFileLocalDataSource {
             for(Loan loan : lista){
                 Date fechaFin = formato.parse(loan.getFechaEnd());
                 if(fechaFin.before(fechaHoy)){
+                    System.out.println("---PRESTAMO " + loan.getId() + "---");
                     System.out.println(loan);
                 }
             }

--- a/src/main/java/com/iesam/digitallibrary/feature/loan/data/local/LoanFileLocalDataSource.java
+++ b/src/main/java/com/iesam/digitallibrary/feature/loan/data/local/LoanFileLocalDataSource.java
@@ -9,10 +9,9 @@ import java.io.FileNotFoundException;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.lang.reflect.Type;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-import java.util.Scanner;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.*;
 
 public class LoanFileLocalDataSource {
     private String nameFile = "Loans.txt";
@@ -114,5 +113,27 @@ public class LoanFileLocalDataSource {
         }
         System.out.println("No se encontró ningún usuario con el id proporcionado.");
     }
+
+    public void getFinishedLoan(){
+        SimpleDateFormat formato = new SimpleDateFormat("dd/MM/yyyy");
+        List<Loan> lista = findAll();
+
+        Date fechaHoy = new Date();
+
+        try{
+
+            for(Loan loan : lista){
+                Date fechaFin = formato.parse(loan.getFechaEnd());
+                if(fechaFin.before(fechaHoy)){
+                    System.out.println(loan);
+                }
+            }
+
+        }catch (ParseException e){
+            System.out.println(e.getMessage());
+        }
+
+    }
+
 
 }

--- a/src/main/java/com/iesam/digitallibrary/feature/loan/domain/GetFinishedLoanUseCase.java
+++ b/src/main/java/com/iesam/digitallibrary/feature/loan/domain/GetFinishedLoanUseCase.java
@@ -1,0 +1,15 @@
+package com.iesam.digitallibrary.feature.loan.domain;
+
+public class GetFinishedLoanUseCase {
+
+    private LoanRepository loanRepository;
+
+    public GetFinishedLoanUseCase(LoanRepository loanRepository) {
+        this.loanRepository = loanRepository;
+    }
+
+    public void execute(){
+        this.loanRepository.getFinishedLoans();
+    }
+
+}

--- a/src/main/java/com/iesam/digitallibrary/feature/loan/domain/Loan.java
+++ b/src/main/java/com/iesam/digitallibrary/feature/loan/domain/Loan.java
@@ -7,18 +7,18 @@ import java.util.Date;
 
 public class Loan {
 
-    private final Date date = new Date();
+
     public final String id;
+
     public final User user;
     public final DigitalBook book;
-    public final String fechaInit;
+    public final Date fechaInit = new Date();
     public final String fechaEnd;
 
-    public Loan(String id, User user, DigitalBook book, String fechaInit, String fechaEnd) {
+    public Loan(String id, User user, DigitalBook book, String fechaEnd) {
         this.id = id;
         this.user = user;
         this.book = book;
-        this.fechaInit = fechaInit;
         this.fechaEnd = fechaEnd;
     }
 
@@ -32,9 +32,6 @@ public class Loan {
                 " FechaEnd = " + fechaEnd + '\n';
     }
 
-    public Date getDate() {
-        return date;
-    }
 
     public String getId() {
         return id;
@@ -48,7 +45,7 @@ public class Loan {
         return book;
     }
 
-    public String getFechaInit() {
+    public Date getFechaInit() {
         return fechaInit;
     }
 

--- a/src/main/java/com/iesam/digitallibrary/feature/loan/domain/LoanRepository.java
+++ b/src/main/java/com/iesam/digitallibrary/feature/loan/domain/LoanRepository.java
@@ -4,5 +4,5 @@ public interface LoanRepository {
 
     void addLoan(Loan loan);
     void deleteLoan(String id);
-
+    void getFinishedLoans();
 }

--- a/src/main/java/com/iesam/digitallibrary/feature/loan/presentation/LoanMain.java
+++ b/src/main/java/com/iesam/digitallibrary/feature/loan/presentation/LoanMain.java
@@ -9,6 +9,7 @@ import com.iesam.digitallibrary.feature.loan.data.local.LoanFileLocalDataSource;
 import com.iesam.digitallibrary.feature.loan.domain.CreateLoanUseCase;
 import com.iesam.digitallibrary.feature.loan.domain.DeleteLoanUseCase;
 
+import com.iesam.digitallibrary.feature.loan.domain.GetFinishedLoanUseCase;
 import com.iesam.digitallibrary.feature.loan.domain.Loan;
 import com.iesam.digitallibrary.feature.user.data.UserDataRepository;
 import com.iesam.digitallibrary.feature.user.data.local.UserFileLocalDataSource;
@@ -41,7 +42,7 @@ public class LoanMain {
         GetDigitalBookUseCase GetDigitalBookUseCase = new GetDigitalBookUseCase(new DigitalBookDataRepository(new DigitalBookFileLocalDataSource()));
         DigitalBook digitalBook = GetDigitalBookUseCase.execute(isbn);
 
-        Loan loan = new Loan(loanId, user, digitalBook,"15/3/2024", "15/4/2024");
+        Loan loan = new Loan(loanId, user, digitalBook,"01/04/2024");
         CreateLoanUseCase createLoanUseCase = new CreateLoanUseCase(new LoanDataRepository(new LoanFileLocalDataSource()));
         createLoanUseCase.execute(loan);
 
@@ -55,6 +56,17 @@ public class LoanMain {
 
         DeleteLoanUseCase deleteLoanUseCase = new DeleteLoanUseCase(new LoanDataRepository(new LoanFileLocalDataSource()));
         deleteLoanUseCase.execute(id);
+
+    }
+
+    public static void getFinishedLoan(){
+
+        System.out.println("---PRESTAMOS FINALIZADOS---");
+
+        GetFinishedLoanUseCase getFinishedLoanUseCase = new GetFinishedLoanUseCase(new LoanDataRepository(new LoanFileLocalDataSource())) ;
+        getFinishedLoanUseCase.execute();
+
+
 
     }
 


### PR DESCRIPTION
## 📝 Breve descripción de lo que se pide en el ejercicio
El cliente ha solicitado la funcionalidad de mostrar los préstanos finalizados. Se necesita la implementación de una serie de componentes, incluyendo un caso de uso para mostrar los préstamos finalizados, y añadir el código necesario al repositorio para gestionar las fuentes de datos y a la fuente de datos local para almacenar la información de los préstamos. Además, se requiere añadir la opción en el menú para seleccionar la visualización de los préstamos finalizados.

## 👩‍💻 Resumen de los cambios introducidos
Se ha implementado un caso de uso para mostrar los préstamos finalizados en el dominio.
Se ha añadido una opción en el menú principal para seleccionar la visualización de los préstamos finalizados en la capa de presentación.

## 📸 Screenshot o Video
https://github.com/CarlosDeMoraGil/ed-digital-library/assets/146753433/97d188c3-240f-439d-81a5-ce9a6256eeb3


## ✋ Notas adicionales (Disclaimer)
Todos los puntos mencionados en la Definición de la Tarea (DoD) se han completado. La opción para mostrar los préstamos finalizados se muestra en el menú principal, se despliega una lista de los préstamos finalizados, y se muestran correctamente en la interfaz de usuario. Se ha completado la tarea según lo requerido por el cliente.
